### PR TITLE
hide new Prelude.<>

### DIFF
--- a/src/Math/Polynomial/Pretty.hs
+++ b/src/Math/Polynomial/Pretty.hs
@@ -11,6 +11,9 @@
 -- |This module exports a 'Pretty' instance for the 'Poly' type.
 module Math.Polynomial.Pretty () where
 
+import qualified Prelude
+import Prelude (Bool(..), RealFloat, Eq(..), Ord(..), Num(..), not, null, otherwise, (&&), zip, (.), filter, ($), drop, repeat, dropWhile, reverse, fst)
+
 import Math.Polynomial.Type
 
 import Data.Complex

--- a/src/Math/Polynomial/Type.hs
+++ b/src/Math/Polynomial/Type.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ViewPatterns, TypeFamilies, GADTs, UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts, ViewPatterns, TypeFamilies, GADTs, UndecidableInstances #-}
 -- |Low-level interface for the 'Poly' type.
 module Math.Polynomial.Type 
     ( Endianness(..)


### PR DESCRIPTION
ghc-8.6 adds a Prelude.<> which as of pretty-1.1.3.6 is
not Text.PrettyPrint.<>. It would be cleaner to have
`import Prelude hiding ((<>))` but that won't work with ghc-7.6